### PR TITLE
Removed hardcoded key names in Redis config 

### DIFF
--- a/lib/econfig/redis.rb
+++ b/lib/econfig/redis.rb
@@ -5,11 +5,11 @@ module Econfig
     end
 
     def get(key)
-      @redis.get("econfig_#{key}")
+      @redis.get("#{key}")
     end
 
     def set(key, value)
-      @redis.set("econfig_#{key}", value)
+      @redis.set("#{key}", value)
     end
   end
 end


### PR DESCRIPTION
I stored some keys directly in Redis that I then wanted to read using Econfig. Took me a while to figure out that I had to prefix them with 'econfig_'. Can't really see why it's hardcoded.
