### PR TITLE
Fix non jvm compliant character

### DIFF
--- a/lib/econfig/backend_collection.rb
+++ b/lib/econfig/backend_collection.rb
@@ -31,23 +31,23 @@ module Econfig
     end
 
     def push(name, backend)
-      exists‽(name)
+      exists?(name)
       @backends.push([name, backend])
     end
     alias_method :use, :push
 
     def unshift(name, backend)
-      exists‽(name)
+      exists?(name)
       @backends.unshift([name, backend])
     end
 
     def insert_before(other, name, backend)
-      exists‽(name)
+      exists?(name)
       @backends.insert(index_of!(other), [name, backend])
     end
 
     def insert_after(other, name, backend)
-      exists‽(name)
+      exists?(name)
       @backends.insert(index_of!(other) + 1, [name, backend])
     end
 
@@ -75,7 +75,7 @@ module Econfig
 
   private
 
-    def exists‽(name)
+    def exists?(name)
       raise KeyError, "#{name} is already set" if index_of(name)
     end
 


### PR DESCRIPTION
When running jRuby 9K (packaged as a WAR in a Tomcat Server), the character you used `‽` creates an internal server error. I have replaced `‽` with `?`.

Error Log:
```
07-Jan-2016 01:12:18.730 SEVERE [localhost-startStop-1] org.apache.catalina.core.ApplicationContext.log ERROR: initialization failed
 org.jruby.rack.RackInitializationException: /Users/cmullen/Developer/Tomcat/webapps/skio-api/WEB-INF/gems/gems/econfig-2.0.0/lib/econfig/backend_collection.rb:23: Invalid char `\200' ('') in expression
      existsâ½(name)
             ^
